### PR TITLE
Adding support to get test information via the api

### DIFF
--- a/autobahntestsuite/autobahntestsuite/case/__init__.py
+++ b/autobahntestsuite/autobahntestsuite/case/__init__.py
@@ -301,6 +301,11 @@ def caseIdtoIdTuple(id):
 def caseIdTupletoId(idt):
    return '.'.join([str(x) for x in list(idt)])
 
+## Truncates the rest of the description after the first HTML tag
+## and coalesces whitespace
+##
+def caseClassToPrettyDescription(klass):
+   return ' '.join(klass.DESCRIPTION.split('<')[0].split())
 
 ## Index:
 ## "1.2.3" => Index (1-based) of Case1_2_3 in Cases


### PR DESCRIPTION
Hi,

I was wondering if I could get this submitted upstream.  Basically it 
adds support to query test result information from within a test harness.

I am trying to use in-app unit tests, and to validate whether or not
the test passed in-line.

To do this, I added a getCaseStatus endpoint.  This will return the
status for the case, agent tuple (if it has been run), otherwise it
will wait for it to be run and then call it once its successful.

The other added endpoint, getCaseInfo will map the case number to the
caseId as well as returning a brief description.

For the brief description, we call caseClassToPrettyDescription which
truncates whitespace, and returns everything to the left of the first
'<' since either invalid unicode or HTML follows.
