### PR TITLE
Fix for UTF8 error

### DIFF
--- a/autobahntestsuite/autobahntestsuite/fuzzing.py
+++ b/autobahntestsuite/autobahntestsuite/fuzzing.py
@@ -813,7 +813,7 @@ class FuzzingFactory:
       ##
       report_filename = self.makeAgentCaseReportFilename(agentId, caseId, ext = 'json')
       f = open(os.path.join(outdir, report_filename), 'w')
-      f.write(json.dumps(case, sort_keys = True, indent = 3, separators = (',', ': ')))
+      f.write(json.dumps(case, sort_keys = True, indent = 3, separators = (',', ': '), encoding = 'ISO-8859-1'))
       f.close()
 
 


### PR DESCRIPTION
I needed to adjust this to get it work as otherwise it bailed out on json.dump(...) during json report generation
