### PR TITLE
Fix incorrect instructions if your path contains spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ To start the testsuite container:
 
 ```console
 docker run -it --rm \
-    -v ${PWD}/config:/config \
-    -v ${PWD}/reports:/reports \
+    -v "${PWD}/config:/config" \
+    -v "${PWD}/reports:/reports" \
     -p 9001:9001 \
     --name fuzzingserver \
     crossbario/autobahn-testsuite


### PR DESCRIPTION
If your working directory contains spaces, which is overwhelmingly likely if running on Windows, the `docker run` call will fail with an error that looks something like this:

````
c:\Program Files\Docker Toolbox\docker.exe: invalid reference format: repository name must be lowercase.
See 'c:\Program Files\Docker Toolbox\docker.exe run --help'.
````

This commit updates the instructions to place the arguments that use the `$PWD` variable in quotes, which fixes the problem.